### PR TITLE
Init Logic component

### DIFF
--- a/src/main/java/jfdi/logic/ControlCenter.java
+++ b/src/main/java/jfdi/logic/ControlCenter.java
@@ -4,6 +4,7 @@ import jfdi.logic.commands.ListCommand;
 import jfdi.logic.interfaces.ILogic;
 import jfdi.storage.records.Task;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -24,9 +25,16 @@ public class ControlCenter implements ILogic {
     public void handleInput(String input) {
         // TODO: Integrate when parser is ready.
         // Right now it is executing a ListCommand no matter what the input is.
+        ArrayList<String> tags = new ArrayList<>();
+        tags.add("deadline");
+        tags.add("work");
+        tags.add("overdue");
+
         ListCommand.Builder builder = new ListCommand.Builder();
-        builder.addTag("important");
-        builder.addTag("urgent");
+        builder.addTag("important")
+            .addTag("urgent")
+            .addTag("personal")
+            .addTags(tags);
         ListCommand ls = builder.build();
         ls.execute();
     }

--- a/src/main/java/jfdi/logic/ControlCenter.java
+++ b/src/main/java/jfdi/logic/ControlCenter.java
@@ -1,0 +1,60 @@
+package jfdi.logic;
+
+import jfdi.logic.commands.ListCommand;
+import jfdi.logic.interfaces.ILogic;
+import jfdi.storage.records.Task;
+
+import java.util.Collection;
+
+/**
+ * @author Liu Xinan
+ */
+public class ControlCenter implements ILogic {
+
+    private static ControlCenter ourInstance = new ControlCenter();
+
+    private ControlCenter() {
+    }
+
+    public static ControlCenter getInstance() {
+        return ourInstance;
+    }
+
+    @Override
+    public void handleInput(String input) {
+        // TODO: Integrate when parser is ready.
+        // Right now it is executing a ListCommand no matter what the input is.
+        ListCommand.Builder builder = new ListCommand.Builder();
+        builder.addTag("important");
+        builder.addTag("urgent");
+        ListCommand ls = builder.build();
+        ls.execute();
+    }
+
+    public static void main(String[] args) {
+        // An example of using ControlCenter and commands.
+
+        ListCommand.addSuccessHook(command -> {
+            Collection<Task> items = command.getItems();
+            for (Task item : items) {
+                System.out.printf("%d. %s\n", item.getId(), item.getDescription());
+            }
+        });
+
+        ListCommand.addFailureHook(command -> {
+            switch (command.getErrorType()) {
+                case NON_EXISTENT_TAG:
+                    break;
+                case UNKNOWN:
+                    System.out.println("Uh-oh");
+                    break;
+                default: break;
+            }
+        });
+
+        ControlCenter cc = ControlCenter.getInstance();
+        cc.handleInput("anything");
+        // Uh-oh
+        // It works!
+    }
+}

--- a/src/main/java/jfdi/logic/commands/ListCommand.java
+++ b/src/main/java/jfdi/logic/commands/ListCommand.java
@@ -1,0 +1,116 @@
+package jfdi.logic.commands;
+
+import jfdi.logic.interfaces.AbstractCommand;
+import jfdi.storage.records.Task;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * @author Liu Xinan
+ */
+public class ListCommand extends AbstractCommand {
+
+    public enum ErrorType {
+        NON_EXISTENT_TAG, UNKNOWN
+    }
+
+    private static ArrayList<Consumer<ListCommand>> successHooks = new ArrayList<>();
+    private static ArrayList<Consumer<ListCommand>> failureHooks = new ArrayList<>();
+
+    private ArrayList<String> tags;
+    private Collection<Task> items = null;
+    private ErrorType errorType = null;
+
+    private ListCommand(Builder builder) {
+        this.tags = builder.tags;
+    }
+
+    public static class Builder {
+
+        ArrayList<String> tags = new ArrayList<>();
+
+        public Builder addTag(String tag) {
+            this.tags.add(tag);
+            return this;
+        }
+
+        public Builder addTags(ArrayList<String> tags) {
+            this.tags.addAll(tags);
+            return this;
+        }
+
+        public ListCommand build() {
+            return new ListCommand(this);
+        }
+    }
+
+    /**
+     * Get the items to for listing.
+     *
+     * @return A Collection of Tasks resulted from the command.
+     */
+    public Collection<Task> getItems() {
+        if (items == null) {
+            throw new IllegalStateException("Command not yet executed!");
+        }
+
+        return items;
+    }
+
+    /**
+     * Get the error type that the command encountered.
+     *
+     * @return Error type
+     */
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    @Override
+    public void execute() {
+        if (tags.isEmpty()) {
+            items = Task.getAll();
+            onSuccess();
+        } else {
+            // TODO: Add filtering when Task supports that.
+            errorType = ErrorType.UNKNOWN;
+            onFailure();
+        }
+    }
+
+    @Override
+    protected void onSuccess() {
+        for (Consumer<ListCommand> hook : successHooks) {
+            hook.accept(this);
+        }
+    }
+
+    @Override
+    protected void onFailure() {
+        for (Consumer<ListCommand> hook : failureHooks) {
+            hook.accept(this);
+        }
+    }
+
+    /**
+     * Add a hook to be run when the command executes successfully.
+     * The hook will be passed the command object as argument.
+     *
+     * @param hook Command hook to be run upon success
+     */
+    public static void addSuccessHook(Consumer<ListCommand> hook) {
+        successHooks.add(hook);
+    }
+
+    /**
+     * Add a hook to be run when the command encounters error.
+     * The hook will be passed the command object as argument.
+     *
+     * @param hook Command hook to be run upon failure
+     */
+    public static void addFailureHook(Consumer<ListCommand> hook) {
+        failureHooks.add(hook);
+    }
+}

--- a/src/main/java/jfdi/logic/interfaces/AbstractCommand.java
+++ b/src/main/java/jfdi/logic/interfaces/AbstractCommand.java
@@ -1,0 +1,25 @@
+package jfdi.logic.interfaces;
+
+/**
+ * @author Liu Xinan
+ */
+public abstract class AbstractCommand {
+
+    /**
+     * Executes the command.
+     */
+    public abstract void execute();
+
+    /**
+     * To be implemented by each command to run the success command hooks.
+     * Pass a reference of self to each hook.
+     */
+    protected abstract void onSuccess();
+
+    /**
+     * To be implemented by each command to run the failure command hooks.
+     * Pass a reference of self to each hook.
+     */
+    protected abstract void onFailure();
+
+}

--- a/src/main/java/jfdi/logic/interfaces/ILogic.java
+++ b/src/main/java/jfdi/logic/interfaces/ILogic.java
@@ -1,0 +1,16 @@
+package jfdi.logic.interfaces;
+
+/**
+ * @author Liu Xinan
+ */
+public interface ILogic {
+
+    /**
+     * Called by UI to handle user input.
+     * It should convert the input to a specific command object and execute it.
+     * It should handle erroneous input as well.
+     *
+     * @param input Input from user
+     */
+    void handleInput(String input);
+}

--- a/src/test/java/jfditests/logictests/ControlCenterTest.java
+++ b/src/test/java/jfditests/logictests/ControlCenterTest.java
@@ -1,0 +1,84 @@
+package jfditests.logictests;
+
+import jfdi.logic.ControlCenter;
+import jfdi.logic.commands.ListCommand;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+/**
+ * @author Liu Xinan
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ControlCenter.class, ListCommand.class})
+public class ControlCenterTest {
+
+    @Mock private ListCommand.Builder builder;
+    @Mock private ListCommand ls;
+
+    private ControlCenter cc = ControlCenter.getInstance();
+
+    @Before
+    public void setUp() throws Exception {
+        // Mocking ListCommand.Builder.
+        when(builder.build()).thenReturn(ls);
+        when(builder.addTag(anyString())).thenReturn(builder);
+        when(builder.addTags(any())).thenReturn(builder);
+        whenNew(ListCommand.Builder.class).withNoArguments().thenReturn(builder);
+
+        // Mocking ListCommand static methods.
+        // i.e. addSuccessHook and addFailureHook
+        mockStatic(ListCommand.class);
+    }
+
+    @Test
+    public void testGetInstance() throws Exception {
+        assertSame(cc, ControlCenter.getInstance());
+        assertSame(ControlCenter.getInstance(), ControlCenter.getInstance());
+    }
+
+    @Test
+    public void testHandleInput() throws Exception {
+        // TODO: Update when Parser is ready
+        // Right now this is an example of using Mockito
+        cc.handleInput("anything");
+
+        InOrder inorder = inOrder(builder);
+
+        inorder.verify(builder).addTag("important");
+        inorder.verify(builder).addTag("urgent");
+        inorder.verify(builder).addTag("personal");
+        inorder.verify(builder).addTags(any());
+        inorder.verify(builder).build();
+        verifyNoMoreInteractions(builder);
+
+        verify(ls).execute();
+        verifyNoMoreInteractions(ls);
+    }
+
+    @Test
+    public void testMain() throws Exception {
+        ControlCenter.main(new String[] {});
+
+        // This is the way to verify that a static method has been called.
+        verifyStatic(times(1));
+        ListCommand.addSuccessHook(any());
+
+        // Each static method call must be prepended by a `verifyStatic()`.
+        verifyStatic(times(1));
+        ListCommand.addFailureHook(any());
+    }
+
+}

--- a/src/test/java/jfditests/logictests/commandstests/ListCommandTest.java
+++ b/src/test/java/jfditests/logictests/commandstests/ListCommandTest.java
@@ -1,0 +1,94 @@
+package jfditests.logictests.commandstests;
+
+import jfdi.logic.commands.ListCommand;
+import jfdi.storage.records.Task;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+/**
+ * @author Liu Xinan
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Task.class})
+public class ListCommandTest {
+
+    @Mock private Collection<Task> items;
+    @Mock private Consumer<ListCommand> successHook;
+    @Mock private Consumer<ListCommand> failureHook;
+
+    private ListCommand listCommandWithTags = new ListCommand.Builder().addTag("test").build();
+    private ListCommand listCommandWithoutTags = new ListCommand.Builder().build();
+
+    @Before
+    public void setUp() throws Exception {
+        mockStatic(Task.class);
+        when(Task.getAll()).thenReturn(items);
+    }
+
+    @Test
+    public void testGetItems() throws Exception {
+        // Command must be executed before there is any items to be gotten.
+        listCommandWithoutTags.execute();
+
+        assertSame(items, listCommandWithoutTags.getItems());
+    }
+
+    @Test
+    public void testGetErrorType() throws Exception {
+        assertNull(listCommandWithTags.getErrorType());
+
+        listCommandWithTags.execute();
+        assertEquals(listCommandWithTags.getErrorType(), ListCommand.ErrorType.UNKNOWN);
+    }
+
+    @Test
+    public void testExecute() throws Exception {
+        listCommandWithoutTags.execute();
+
+        verifyStatic();
+        Task.getAll(); // @CheckReturnValue
+    }
+
+    @Test
+    public void testOnSuccess() throws Exception {
+        ListCommand.addSuccessHook(successHook);
+        listCommandWithoutTags.execute();
+
+        verify(successHook).accept(listCommandWithoutTags);
+    }
+
+    @Test
+    public void testOnFailure() throws Exception {
+        ListCommand.addFailureHook(failureHook);
+        listCommandWithTags.execute();
+
+        verify(failureHook).accept(listCommandWithTags);
+    }
+
+    @Test
+    public void testAddSuccessHook() throws Exception {
+        ListCommand.addSuccessHook(successHook);
+        listCommandWithoutTags.execute();
+
+        verify(successHook).accept(listCommandWithoutTags);
+    }
+
+    @Test
+    public void testAddFailureHook() throws Exception {
+        ListCommand.addFailureHook(failureHook);
+        listCommandWithTags.execute();
+
+        verify(failureHook).accept(listCommandWithTags);
+    }
+}

--- a/src/test/java/jfditests/logictests/commandstests/ListCommandTest.java
+++ b/src/test/java/jfditests/logictests/commandstests/ListCommandTest.java
@@ -32,6 +32,7 @@ public class ListCommandTest {
 
     @Before
     public void setUp() throws Exception {
+        // Mocking Task
         mockStatic(Task.class);
         when(Task.getAll()).thenReturn(items);
     }
@@ -57,11 +58,11 @@ public class ListCommandTest {
         listCommandWithoutTags.execute();
 
         verifyStatic();
-        Task.getAll(); // @CheckReturnValue
+        Task.getAll();
     }
 
     @Test
-    public void testOnSuccess() throws Exception {
+    public void testAddSuccessHookAndOnSuccess() throws Exception {
         ListCommand.addSuccessHook(successHook);
         listCommandWithoutTags.execute();
 
@@ -69,26 +70,11 @@ public class ListCommandTest {
     }
 
     @Test
-    public void testOnFailure() throws Exception {
+    public void testAddFailureHookAndOnFailure() throws Exception {
         ListCommand.addFailureHook(failureHook);
         listCommandWithTags.execute();
 
         verify(failureHook).accept(listCommandWithTags);
     }
 
-    @Test
-    public void testAddSuccessHook() throws Exception {
-        ListCommand.addSuccessHook(successHook);
-        listCommandWithoutTags.execute();
-
-        verify(successHook).accept(listCommandWithoutTags);
-    }
-
-    @Test
-    public void testAddFailureHook() throws Exception {
-        ListCommand.addFailureHook(failureHook);
-        listCommandWithTags.execute();
-
-        verify(failureHook).accept(listCommandWithTags);
-    }
 }


### PR DESCRIPTION
I have included:
- (For UI) An example of using `ControlCenter` and `ListCommand` in `ControlCenter.main(String[] args)`. 
- (For Parser) An example of how to build a `ListCommand` in `ControlCenter.handleInput(String input)`. 

Feel free to give suggestions and comments.

If everything seems fine I will merge it and start implementing other commands in a similar way.

Ps. Due to the reason that java shares all static members among parent classes and child classes, I would have to duplicate all those hook supporting code in each command class. :sweat_smile: 