### PR TITLE
Add command validation for aliases

### DIFF
--- a/src/main/java/jfdi/storage/Constants.java
+++ b/src/main/java/jfdi/storage/Constants.java
@@ -77,6 +77,8 @@ public class Constants {
     public static final String TEST_COMMAND = "somecommand";
     public static final String TEST_ALIAS_2 = "somealias2";
     public static final String TEST_COMMAND_2 = "somecommand2";
+    public static final String TEST_COMMAND_REGEX = "(?i)^(" + TEST_COMMAND + ")|"
+            + "(?i)^(" + TEST_COMMAND_2 + ")";
 
     // Tasks
     public static final String TEST_TASK_DESCRIPTION_1 = "my favourite description";

--- a/src/main/java/jfdi/storage/apis/AliasAttributes.java
+++ b/src/main/java/jfdi/storage/apis/AliasAttributes.java
@@ -6,6 +6,9 @@ import jfdi.storage.exceptions.InvalidAliasParametersException;
 
 public class AliasAttributes {
 
+    // The regex for checking if a given word is a valid command
+    private static String commandRegex = null;
+
     private String alias;
     private String command;
 
@@ -19,12 +22,34 @@ public class AliasAttributes {
         this.command = command;
     }
 
+    /**
+     * Sets the regex used for checking if a given word is a valid command.
+     *
+     * @param regex the regex that checks if a given word is a command command
+     */
+    public static void setCommandRegex(String regex) {
+        commandRegex = regex;
+    }
+
     public String getAlias() {
         return alias;
     }
 
     public String getCommand() {
         return command;
+    }
+
+    /**
+     * This method checks if a given string matches the command regex (i.e. if a
+     * string is a command word).
+     *
+     * @param input
+     *            the string to be checked
+     * @return boolean indicating if the input is a command word
+     */
+    private boolean isValidCommand(String input) {
+        assert commandRegex != null;
+        return input.matches(commandRegex);
     }
 
     /**
@@ -46,7 +71,7 @@ public class AliasAttributes {
     }
 
     private void validateAttributes() throws InvalidAliasParametersException, DuplicateAliasException {
-        if (alias == null || command == null) {
+        if (alias == null || command == null || !isValidCommand(command)) {
             throw new InvalidAliasParametersException(this);
         }
     }

--- a/src/test/java/jfdi/test/storage/AliasAttributesTest.java
+++ b/src/test/java/jfdi/test/storage/AliasAttributesTest.java
@@ -28,6 +28,7 @@ public class AliasAttributesTest {
         MainStorage fileStorageInstance = MainStorage.getInstance();
         fileStorageInstance.load(testDirectory.toString());
         aliasDbInstance = AliasDb.getInstance();
+        AliasAttributes.setCommandRegex(Constants.TEST_COMMAND_REGEX);
     }
 
     @After
@@ -50,14 +51,20 @@ public class AliasAttributesTest {
     }
 
     @Test(expected = InvalidAliasParametersException.class)
-    public void testInvalidAliasSave() throws Exception {
+    public void testNullAliasSave() throws Exception {
         AliasAttributes aliasAttributes = new AliasAttributes(null, Constants.TEST_COMMAND);
         aliasAttributes.save();
     }
 
     @Test(expected = InvalidAliasParametersException.class)
-    public void testInvalidCommandSave() throws Exception {
+    public void testNullCommandSave() throws Exception {
         AliasAttributes aliasAttributes = new AliasAttributes(Constants.TEST_ALIAS, null);
+        aliasAttributes.save();
+    }
+
+    @Test(expected = InvalidAliasParametersException.class)
+    public void testInvalidCommandSave() throws Exception {
+        AliasAttributes aliasAttributes = new AliasAttributes(Constants.TEST_ALIAS, Constants.TEST_ALIAS);
         aliasAttributes.save();
     }
 

--- a/src/test/java/jfdi/test/storage/AliasDbTest.java
+++ b/src/test/java/jfdi/test/storage/AliasDbTest.java
@@ -32,6 +32,7 @@ public class AliasDbTest {
         MainStorage fileStorageInstance = MainStorage.getInstance();
         fileStorageInstance.load(testDirectory.toString());
         aliasDbInstance = AliasDb.getInstance();
+        AliasAttributes.setCommandRegex(Constants.TEST_COMMAND_REGEX);
     }
 
     @After


### PR DESCRIPTION
@xinan please use `getAllCommandRegexes()` from *IParser* and `setCommandRegex` from *AliasAttributes* to set the list of permitted commands that can be aliased. This should be done before *MainStorage* is initialized because we would want to be able to validate the data that is on disk when we load them (which happens when *MainStorage* is initialized).

Closes #149.